### PR TITLE
Updated Google Analytics script

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -32,6 +32,7 @@
 
     <%= stylesheet_link_tag    'application', media: 'all', 'data-turbolinks-track': 'reload' %>
     <%= javascript_include_tag 'application', 'data-turbolinks-track': 'reload' %>
+    <%= render 'layouts/scripts/ga' %>
 
   </head>
 
@@ -39,8 +40,6 @@
     <%= yield %>
 
     <%= render 'layouts/scripts/flash' %>
-    <%= render 'layouts/scripts/ga' %>
-
     <%= yield :extra_scripts %>
   </body>
 </html>

--- a/app/views/layouts/scripts/_ga.html.erb
+++ b/app/views/layouts/scripts/_ga.html.erb
@@ -4,7 +4,14 @@
     window.dataLayer = window.dataLayer || [];
     function gtag(){dataLayer.push(arguments);}
     gtag('js', new Date());
-
     gtag('config', '<%= analytics %>');
+
+    document.addEventListener('turbolinks:load', event => {
+    if (typeof gtag === 'function') {
+      gtag('config', '<%= analytics %>', {
+        'page_location': event.data.url
+      });
+    }
+  });
   </script>
 <% end %>


### PR DESCRIPTION
Google has rolled out a new way to send your data to Google Analytics, Adwords and more called gtag.js. This seems to be the new default when adding new properties to Google Analytics. The old guides for how to integrate Turbolinks with Google Analytics no longer work with gtag.js.

I've updated the way the Google Analytics code works with Turbolinks by listening to `turbolinks:load` events and sending the page URL using the new gtag `config` function.

